### PR TITLE
create new zone method

### DIFF
--- a/dns_zones_test.go
+++ b/dns_zones_test.go
@@ -1,8 +1,9 @@
 package cloudns
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestZoneService_AvailableNameservers(t *testing.T) {
@@ -89,4 +90,15 @@ func TestZoneService_GetUsage(t *testing.T) {
 
 	_, err := client.Zones.GetUsage(ctx)
 	assert.NoError(t, err, "should not fail")
+}
+
+func TestZoneService_Create(t *testing.T) {
+	teardown := setup(t)
+	defer teardown()
+
+	zone := NewZone("sampion.io", ZoneTypeMaster, []string{}, "")
+	_, err := client.Zones.Create(ctx, zone)
+	if err != nil {
+		t.Fatalf("Records.Create() returned error: %v", err)
+	}
 }

--- a/fixtures/TestZoneService_Create.yaml
+++ b/fixtures/TestZoneService_Create.yaml
@@ -1,0 +1,105 @@
+---
+version: 2
+interactions:
+    - id: 0
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.cloudns.net
+        remote_addr: ""
+        request_uri: ""
+        body: '{"domain-name":"sampion.io","ns":[],"zone-type":"master"}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/json
+            User-Agent:
+                - cloudns-go/test
+        url: https://api.cloudns.net/dns/add-record.json
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"Failed","statusDescription":"Invalid authentication, incorrect user ID or password."}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Sat, 04 Mar 2023 08:51:41 GMT
+            Server:
+                - nginx
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubdomains; preload
+            Vary:
+                - Accept-Encoding
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 605.6862ms
+    - id: 1
+      request:
+        proto: HTTP/1.1
+        proto_major: 1
+        proto_minor: 1
+        content_length: 0
+        transfer_encoding: []
+        trailer: {}
+        host: api.cloudns.net
+        remote_addr: ""
+        request_uri: ""
+        body: '{"domain-name":"sampion.io","ns":[],"zone-type":"master"}'
+        form: {}
+        headers:
+            Accept:
+                - application/json
+            Content-Type:
+                - application/json
+            User-Agent:
+                - cloudns-go/test
+        url: https://api.cloudns.net/dns/register.json
+        method: POST
+      response:
+        proto: HTTP/2.0
+        proto_major: 2
+        proto_minor: 0
+        transfer_encoding: []
+        trailer: {}
+        content_length: -1
+        uncompressed: true
+        body: '{"status":"Failed","statusDescription":"Invalid authentication, incorrect user ID or password."}'
+        headers:
+            Content-Type:
+                - application/json
+            Date:
+                - Sat, 04 Mar 2023 09:26:16 GMT
+            Server:
+                - nginx
+            Strict-Transport-Security:
+                - max-age=31536000; includeSubdomains; preload
+            Vary:
+                - Accept-Encoding
+            X-Content-Type-Options:
+                - nosniff
+            X-Frame-Options:
+                - SAMEORIGIN
+            X-Xss-Protection:
+                - 1; mode=block
+        status: 200 OK
+        code: 200
+        duration: 734.0522ms

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ppmathis/cloudns-go
+module github.com/inamvar/cloudns-go
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/inamvar/cloudns-go
+module github.com/ppmathis/cloudns-go
 
 go 1.16
 


### PR DESCRIPTION
create new zone functionality added to ```zones``` servrice as ```Create``` method.

 usage:
``` go
domainName :="example.com"
zone := cloudns.NewZone(domainName, cloudns.ZoneTypeMaster,
		[]string{
			"a.ns.customns.com",  //optional
			"b.ns.customns.com", // optional
                         },
		"")

res, err := client.Zones.Create(context.TODO(), zone)

```